### PR TITLE
feat(cms): add ica-report and urban-forestry collections

### DIFF
--- a/scripts/bulk-import.js
+++ b/scripts/bulk-import.js
@@ -1,0 +1,144 @@
+const axios = require('axios');
+
+// --- CONFIGURACIÓN ---
+// 1. Pega aquí tu API Token de Strapi. Encuéntralo en Settings > API Tokens.
+//    Asegúrate de que el token tenga permisos de 'Create' para 'Ica-report'.
+const STRAPI_API_TOKEN = 'YOUR_API_TOKEN_HERE';
+const STRAPI_API_URL = 'http://localhost:1337/api/ica-reports';
+
+const generateDaysArray = (n, start = 1) => Array.from({ length: n }, (_, i) => i + start);
+
+// Datos completos de los reportes extraídos de icaReport.ts
+const sourceReports = [
+  { date: { year: 2025, month: 5, days: generateDaysArray(31) } },
+  { date: { year: 2025, month: 4, days: generateDaysArray(30) } },
+  { date: { year: 2025, month: 3, days: generateDaysArray(31) } },
+  { date: { year: 2025, month: 1, days: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 26, 27, 28, 29, 30, 31] } },
+  { date: { year: 2024, month: 12, days: generateDaysArray(31) } },
+  { date: { year: 2024, month: 10, days: generateDaysArray(31) } },
+  { date: { year: 2024, month: 9, days: generateDaysArray(30) } },
+  { date: { year: 2024, month: 8, days: generateDaysArray(31) } },
+  { date: { year: 2024, month: 7, days: generateDaysArray(31) } },
+  { date: { year: 2024, month: 6, days: generateDaysArray(30) } },
+  { date: { year: 2024, month: 5, days: generateDaysArray(31) } },
+  { date: { year: 2024, month: 4, days: generateDaysArray(30) } },
+  { date: { year: 2024, month: 3, days: generateDaysArray(31) } },
+  { date: { year: 2024, month: 2, days: generateDaysArray(29) } },
+  { date: { year: 2024, month: 1, days: generateDaysArray(31) } },
+  { date: { year: 2023, month: 12, days: generateDaysArray(31) } },
+  { date: { year: 2023, month: 11, days: generateDaysArray(30) } },
+  { date: { year: 2023, month: 10, days: generateDaysArray(31) } },
+  { date: { year: 2023, month: 9, days: generateDaysArray(30) } },
+  { date: { year: 2023, month: 8, days: generateDaysArray(31) } },
+  { date: { year: 2023, month: 7, days: generateDaysArray(31) } },
+  { date: { year: 2023, month: 6, days: generateDaysArray(30) } },
+  { date: { year: 2023, month: 5, days: generateDaysArray(31) } },
+  { date: { year: 2023, month: 4, days: generateDaysArray(30) } },
+  { date: { year: 2023, month: 3, days: generateDaysArray(31) } },
+  { date: { year: 2023, month: 2, days: generateDaysArray(28) } },
+  { date: { year: 2023, month: 1, days: generateDaysArray(31) } },
+  { date: { year: 2022, month: 12, days: generateDaysArray(31) } },
+  { date: { year: 2022, month: 11, days: generateDaysArray(30) } },
+  { date: { year: 2022, month: 10, days: generateDaysArray(31) } },
+  { date: { year: 2022, month: 9, days: generateDaysArray(30) } },
+  { date: { year: 2022, month: 8, days: generateDaysArray(31) } },
+  { date: { year: 2022, month: 7, days: generateDaysArray(31) } },
+  { date: { year: 2022, month: 6, days: generateDaysArray(30) } },
+  { date: { year: 2022, month: 5, days: generateDaysArray(31) } },
+  { date: { year: 2022, month: 4, days: generateDaysArray(30) } },
+  { date: { year: 2022, month: 3, days: generateDaysArray(31) } },
+  { date: { year: 2022, month: 2, days: generateDaysArray(28) } },
+  { date: { year: 2022, month: 1, days: generateDaysArray(31) } },
+  { date: { year: 2021, month: 12, days: generateDaysArray(31) } },
+  { date: { year: 2021, month: 11, days: generateDaysArray(30) } },
+  { date: { year: 2021, month: 10, days: generateDaysArray(31) } },
+  { date: { year: 2021, month: 9, days: generateDaysArray(30) } },
+  { date: { year: 2021, month: 8, days: generateDaysArray(31) } },
+  { date: { year: 2021, month: 7, days: generateDaysArray(31) } },
+  { date: { year: 2021, month: 6, days: generateDaysArray(30) } },
+  { date: { year: 2021, month: 5, days: generateDaysArray(31) } },
+  { date: { year: 2021, month: 4, days: generateDaysArray(30) } },
+  { date: { year: 2021, month: 3, days: generateDaysArray(31) } },
+  { date: { year: 2021, month: 2, days: generateDaysArray(28) } },
+  { date: { year: 2021, month: 1, days: generateDaysArray(31) } },
+  { date: { year: 2020, month: 12, days: generateDaysArray(31) } },
+  { date: { year: 2020, month: 11, days: generateDaysArray(30) } },
+  { date: { year: 2020, month: 10, days: generateDaysArray(31) } },
+  { date: { year: 2020, month: 9, days: generateDaysArray(30) } },
+  { date: { year: 2020, month: 8, days: generateDaysArray(31) } },
+  { date: { year: 2020, month: 7, days: generateDaysArray(31) } },
+  { date: { year: 2020, month: 6, days: generateDaysArray(30) } },
+  { date: { year: 2020, month: 5, days: generateDaysArray(31) } },
+  { date: { year: 2020, month: 4, days: generateDaysArray(30) } },
+  { date: { year: 2020, month: 3, days: generateDaysArray(31) } },
+  { date: { year: 2020, month: 2, days: generateDaysArray(29) } },
+  { date: { year: 2020, month: 1, days: generateDaysArray(31) } },
+  { date: { year: 2019, month: 12, days: generateDaysArray(31) } },
+  { date: { year: 2019, month: 11, days: generateDaysArray(30) } },
+  { date: { year: 2019, month: 10, days: generateDaysArray(31) } },
+  { date: { year: 2019, month: 9, days: generateDaysArray(30) } },
+  { date: { year: 2019, month: 8, days: generateDaysArray(31) } },
+  { date: { year: 2019, month: 7, days: generateDaysArray(31) } },
+  { date: { year: 2019, month: 6, days: generateDaysArray(30) } },
+  { date: { year: 2019, month: 5, days: generateDaysArray(31) } },
+  { date: { year: 2019, month: 4, days: generateDaysArray(30) } },
+  { date: { year: 2019, month: 3, days: generateDaysArray(31) } },
+  { date: { year: 2019, month: 2, days: generateDaysArray(28) } },
+  { date: { year: 2019, month: 1, days: generateDaysArray(31) } },
+];
+
+const monthNames = ["Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"];
+
+function processAndSortReports(reports) {
+    const allReports = [];
+    reports.forEach(reportEntry => {
+        const group = reportEntry.date;
+        group.days.forEach(day => {
+            allReports.push({ year: group.year, month: group.month, day: day });
+        });
+    });
+
+    allReports.sort((a, b) => new Date(a.year, a.month - 1, a.day) - new Date(b.year, b.month - 1, b.day));
+
+    return allReports;
+}
+
+function formatTitle(dateObj) {
+    const day = dateObj.day;
+    const month = monthNames[dateObj.month - 1];
+    const year = dateObj.year;
+    return `Reporte del ${day} de ${month} de ${year}`;
+}
+
+async function createReport(title) {
+    try {
+        const response = await axios.post(STRAPI_API_URL, {
+            data: { title: title }
+        }, {
+            headers: { 'Authorization': `Bearer ${STRAPI_API_TOKEN}` }
+        });
+        console.log(`Reporte creado: ${title} (ID: ${response.data.data.id})`);
+    } catch (error) {
+        console.error(`Error creando reporte '${title}':`, error.response ? error.response.data : error.message);
+    }
+}
+
+async function main() {
+    if (STRAPI_API_TOKEN === 'YOUR_API_TOKEN_HERE') {
+        console.error('Por favor, reemplaza YOUR_API_TOKEN_HERE con tu token de API de Strapi en el script.');
+        return;
+    }
+
+    const reportsToCreate = processAndSortReports(sourceReports);
+    console.log(`Iniciando importación de ${reportsToCreate.length} reportes...`);
+
+    for (const dateObj of reportsToCreate) {
+        const title = formatTitle(dateObj);
+        await createReport(title);
+        await new Promise(resolve => setTimeout(resolve, 100)); // Pausa para no sobrecargar la API
+    }
+
+    console.log('Importación completada.');
+}
+
+main();

--- a/scripts/update-reports-with-pdf.js
+++ b/scripts/update-reports-with-pdf.js
@@ -1,0 +1,147 @@
+const axios = require('axios');
+const FormData = require('form-data');
+const path = require('path');
+
+// --- CONFIGURACIÓN ---
+// 1. Pega aquí tu API Token de Strapi.
+//    Asegúrate de que el token tenga permisos de 'Create', 'Update' para 'Ica-report' y 'Upload' para la Mediateca.
+const STRAPI_API_TOKEN = 'YOUR_API_TOKEN_HERE';
+const STRAPI_BASE_URL = 'http://localhost:1337/api';
+
+// --- DATOS DE PRUEBA ---
+// Como prueba, solo se procesarán los reportes del 30 y 31 de mayo de 2025.
+const reportsToUpdate = [
+  {
+    link: "http://api.barranquillaverde.gov.co/storage/app/media/calidad-aire/30-05-25%20ICA.pdf",
+    date: { year: 2025, month: 5, day: 30 },
+  },
+  {
+    link: "http://api.barranquillaverde.gov.co/storage/app/media/calidad-aire/31-05-25%20ICA.pdf",
+    date: { year: 2025, month: 5, day: 31 },
+  },
+];
+
+const monthNames = ["Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"];
+
+// --- FUNCIONES AUXILIARES ---
+
+// Formatea el título de la misma forma que el script de importación masiva.
+function formatTitle(dateObj) {
+  const day = dateObj.day;
+  const month = monthNames[dateObj.month - 1];
+  const year = dateObj.year;
+  return `Reporte del ${day} de ${month} de ${year}`;
+}
+
+// Descarga el archivo PDF desde una URL y devuelve un buffer.
+async function downloadPdf(url) {
+  try {
+    const response = await axios.get(url, { responseType: 'arraybuffer' });
+    console.log(`PDF descargado de ${url}`);
+    return Buffer.from(response.data);
+  } catch (error) {
+    console.error(`Error al descargar el PDF de ${url}:`, error.message);
+    throw error;
+  }
+}
+
+// Sube el buffer del PDF a la mediateca de Strapi.
+async function uploadPdfToStrapi(pdfBuffer, reportDate) {
+  const formData = new FormData();
+  const fileName = `${reportDate.year}-${reportDate.month}-${reportDate.day}-reporte-ica.pdf`;
+
+  formData.append('files', pdfBuffer, fileName);
+
+  try {
+    const response = await axios.post(`${STRAPI_BASE_URL}/upload`, formData, {
+      headers: {
+        ...formData.getHeaders(),
+        'Authorization': `Bearer ${STRAPI_API_TOKEN}`,
+      },
+    });
+    console.log(`PDF ${fileName} subido a Strapi. ID: ${response.data[0].id}`);
+    return response.data[0].id; // Devuelve el ID del archivo subido
+  } catch (error) {
+    console.error(`Error al subir el PDF a Strapi:`, error.response?.data || error.message);
+    throw error;
+  }
+}
+
+// Actualiza un reporte existente en Strapi para asignarle el PDF.
+async function updateReportWithPdf(reportId, pdfId) {
+  try {
+    await axios.put(`${STRAPI_BASE_URL}/ica-reports/${reportId}`,
+      { data: { report_pdf: pdfId } },
+      {
+        headers: {
+          'Authorization': `Bearer ${STRAPI_API_TOKEN}`,
+        },
+      }
+    );
+    console.log(`Reporte con ID ${reportId} actualizado con el PDF ID ${pdfId}.`);
+  } catch (error) {
+    console.error(`Error al actualizar el reporte ${reportId}:`, error.response?.data || error.message);
+    throw error;
+  }
+}
+
+// --- FUNCIÓN PRINCIPAL ---
+async function main() {
+  console.log('Iniciando el script de actualización de PDFs...');
+
+  // 1. Obtener TODOS los reportes de Strapi, manejando la paginación.
+  let allStrapiReports = [];
+  let page = 1;
+  let pageCount = 1;
+  console.log('Obteniendo todos los reportes de Strapi...');
+  try {
+    do {
+      const response = await axios.get(`${STRAPI_BASE_URL}/ica-reports?pagination[page]=${page}&pagination[pageSize]=100`, {
+        headers: { 'Authorization': `Bearer ${STRAPI_API_TOKEN}` }
+      });
+
+      if (response.data && response.data.data) {
+        allStrapiReports = allStrapiReports.concat(response.data.data);
+        pageCount = response.data.meta.pagination.pageCount;
+        console.log(`  -> Página ${page} de ${pageCount} obtenida.`);
+        page++;
+      } else {
+        break; // Detener si no hay más datos
+      }
+    } while (page <= pageCount);
+
+    console.log(`Se encontraron un total de ${allStrapiReports.length} reportes en Strapi.`);
+  } catch (error) {
+    console.error('Error fatal: No se pudieron obtener los reportes de Strapi.', error.message);
+    return; // Detener si no podemos obtener los reportes
+  }
+
+  // 2. Procesar cada reporte de la lista de prueba.
+  for (const report of reportsToUpdate) {
+    const titleToFind = formatTitle(report.date);
+    console.log(`\nProcesando: ${titleToFind}`);
+
+    const strapiReport = allStrapiReports.find(r => r.attributes.title === titleToFind);
+
+    if (!strapiReport) {
+      console.warn(`  -> No se encontró el reporte con título "${titleToFind}" en Strapi. Saltando...`);
+      continue;
+    }
+
+    console.log(`  -> Reporte encontrado en Strapi con ID: ${strapiReport.id}`);
+
+    try {
+      // 3. Descargar, subir y actualizar.
+      const pdfBuffer = await downloadPdf(report.link);
+      const pdfId = await uploadPdfToStrapi(pdfBuffer, report.date);
+      await updateReportWithPdf(strapiReport.id, pdfId);
+      console.log(`  -> ¡Éxito! El reporte "${titleToFind}" ha sido actualizado con su PDF.`);
+    } catch (error) {
+      console.error(`  -> Falló el proceso para "${titleToFind}".`);
+    }
+  }
+
+  console.log('\nScript finalizado.');
+}
+
+main();

--- a/src/api/ica-report/content-types/ica-report/schema.json
+++ b/src/api/ica-report/content-types/ica-report/schema.json
@@ -16,7 +16,7 @@
       "type": "string",
       "required": true
     },
-    "report_pdf": {
+    "report": {
       "type": "media",
       "multiple": false,
       "required": false,

--- a/src/api/ica-report/content-types/ica-report/schema.json
+++ b/src/api/ica-report/content-types/ica-report/schema.json
@@ -1,0 +1,28 @@
+{
+  "kind": "collectionType",
+  "collectionName": "ica_reports",
+  "info": {
+    "singularName": "ica-report",
+    "pluralName": "ica-reports",
+    "displayName": "ICAReports",
+    "description": "Colección para almacenar los reportes de calidad de aire (ICA)"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "report_pdf": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "files"
+      ]
+    }
+  }
+}

--- a/src/api/ica-report/controllers/ica-report.js
+++ b/src/api/ica-report/controllers/ica-report.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * ica-report controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::ica-report.ica-report');

--- a/src/api/ica-report/routes/ica-report.js
+++ b/src/api/ica-report/routes/ica-report.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * ica-report router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::ica-report.ica-report');

--- a/src/api/ica-report/services/ica-report.js
+++ b/src/api/ica-report/services/ica-report.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * ica-report service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::ica-report.ica-report');

--- a/src/api/urban-forestry-document/content-types/urban-forestry-document/schema.json
+++ b/src/api/urban-forestry-document/content-types/urban-forestry-document/schema.json
@@ -1,0 +1,32 @@
+{
+  "kind": "collectionType",
+  "collectionName": "urban_forestry_documents",
+  "info": {
+    "singularName": "urban-forestry-document",
+    "pluralName": "urban-forestry-documents",
+    "displayName": "Urban Forestry Document",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "text",
+      "required": true
+    },
+    "document": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "files"
+      ]
+    }
+  }
+}

--- a/src/api/urban-forestry-document/controllers/urban-forestry-document.js
+++ b/src/api/urban-forestry-document/controllers/urban-forestry-document.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * urban-forestry-document controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::urban-forestry-document.urban-forestry-document');

--- a/src/api/urban-forestry-document/routes/urban-forestry-document.js
+++ b/src/api/urban-forestry-document/routes/urban-forestry-document.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * urban-forestry-document router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::urban-forestry-document.urban-forestry-document');

--- a/src/api/urban-forestry-document/services/urban-forestry-document.js
+++ b/src/api/urban-forestry-document/services/urban-forestry-document.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * urban-forestry-document service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::urban-forestry-document.urban-forestry-document');


### PR DESCRIPTION
Defines the schemas, controllers, services, and routes for the `ica-report` and `urban-forestry-document` collection types. Adds utility scripts for bulk data import and for attaching PDF files to existing reports, organized in a new /scripts directory.