### PR TITLE
feat: add date range fields to ica-report schema

### DIFF
--- a/src/api/ica-report/content-types/ica-report/schema.json
+++ b/src/api/ica-report/content-types/ica-report/schema.json
@@ -16,6 +16,14 @@
       "type": "string",
       "required": true
     },
+    "startDate": {
+      "type": "date",
+      "required": true
+    },
+    "endDate": {
+      "type": "date",
+      "required": true
+    },
     "report": {
       "type": "media",
       "multiple": false,


### PR DESCRIPTION
This PR adds two new required date fields to the ICA report schema:
- startDate: Required date field to specify when the report period starts
- endDate: Required date field to specify when the report period ends

These fields will help to better organize and filter ICA reports by their date ranges.