### PR TITLE
Feature/main modal collection

### DIFF
--- a/src/api/ica-report/content-types/ica-report/schema.json
+++ b/src/api/ica-report/content-types/ica-report/schema.json
@@ -16,6 +16,14 @@
       "type": "string",
       "required": true
     },
+    "startDate": {
+      "type": "date",
+      "required": true
+    },
+    "endDate": {
+      "type": "date",
+      "required": true
+    },
     "report": {
       "type": "media",
       "multiple": false,

--- a/src/api/main-modal/content-types/main-modal/schema.json
+++ b/src/api/main-modal/content-types/main-modal/schema.json
@@ -1,0 +1,48 @@
+{
+  "kind": "singleType",
+  "collectionName": "main_modals",
+  "info": {
+    "singularName": "main-modal",
+    "pluralName": "main-modals",
+    "displayName": "Main Modal",
+    "description": "Configuration for the main modal displayed on the homepage"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "internalTitle": {
+      "type": "string",
+      "required": true,
+      "description": "Internal reference title for this modal"
+    },
+    "isActive": {
+      "type": "boolean",
+      "default": false,
+      "required": true,
+      "description": "Controls whether the modal should be displayed"
+    },
+    "featuredImage": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": [
+        "images"
+      ],
+      "description": "The image to be displayed in the modal"
+    },
+    "link": {
+      "type": "string",
+      "description": "Optional URL where users will be redirected when clicking the modal"
+    },
+    "startDate": {
+      "type": "datetime",
+      "description": "Optional start date for when the modal should begin displaying"
+    },
+    "endDate": {
+      "type": "datetime",
+      "description": "Optional end date for when the modal should stop displaying"
+    }
+  }
+} 

--- a/src/api/main-modal/controllers/main-modal.js
+++ b/src/api/main-modal/controllers/main-modal.js
@@ -1,0 +1,38 @@
+'use strict';
+
+/**
+ * main-modal controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::main-modal.main-modal', ({ strapi }) => ({
+  async find(ctx) {
+    ctx.query = {
+      ...ctx.query,
+      populate: {
+        featuredImage: true
+      }
+    };
+
+    const entity = await super.find(ctx);
+    
+    // Si no hay entidad o no está activa, retornamos null
+    if (!entity?.data?.attributes?.isActive) {
+      return { data: null, meta: entity.meta };
+    }
+
+    const { startDate, endDate } = entity.data.attributes;
+    const now = new Date();
+
+    // Verificar si estamos dentro del rango de fechas (si se especificaron)
+    if (startDate && new Date(startDate) > now) {
+      return { data: null, meta: entity.meta };
+    }
+    if (endDate && new Date(endDate) < now) {
+      return { data: null, meta: entity.meta };
+    }
+
+    return entity;
+  }
+})); 

--- a/src/api/main-modal/routes/main-modal.js
+++ b/src/api/main-modal/routes/main-modal.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * main-modal router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::main-modal.main-modal', {
+  config: {
+    find: {
+      auth: false,
+      policies: [],
+      middlewares: []
+    },
+    findOne: {
+      auth: false,
+      policies: [],
+      middlewares: []
+    }
+  }
+}); 

--- a/src/api/main-modal/services/main-modal.js
+++ b/src/api/main-modal/services/main-modal.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * main-modal service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::main-modal.main-modal'); 


### PR DESCRIPTION
Main Modal Single Type Collection Implementation

This PR adds a new single type collection to manage the main modal content displayed on the frontend.

Changes Made:
- Created main-modal single type collection
- Implemented schema with required fields:
  - internalTitle (string, required)
  - isActive (boolean, required)
  - featuredImage (media, required)
  - link (string)
  - startDate (datetime)
  - endDate (datetime)
- Added necessary API configurations and permissions

Technical Details:
- Single type pattern used for unique modal instance
- Proper field validations implemented
- Media handling configured for image uploads
- RESTful endpoints configured for frontend consumption

Testing:
- Verify all fields are saving correctly
- Confirm image upload functionality
- Test API endpoints responses
- Check permissions and roles access
- Validate datetime fields format

API Endpoints:
- GET /api/main-modal