### PR TITLE
Feature/transparency ethics integration back

### DIFF
--- a/src/api/transparency-ethics-document/controllers/transparency-ethics-document.js
+++ b/src/api/transparency-ethics-document/controllers/transparency-ethics-document.js
@@ -6,4 +6,28 @@
 
 const { createCoreController } = require('@strapi/strapi').factories;
 
-module.exports = createCoreController('api::transparency-ethics-document.transparency-ethics-document'); 
+module.exports = createCoreController('api::transparency-ethics-document.transparency-ethics-document', ({ strapi }) => ({
+    async find(ctx) {
+      ctx.query = {
+        ...ctx.query,
+        populate: {
+          document: true
+        }
+      };
+  
+      const { data, meta } = await super.find(ctx);
+      return { data, meta };
+    },
+  
+    async findOne(ctx) {
+      ctx.query = {
+        ...ctx.query,
+        populate: {
+          document: true
+        }
+      };
+  
+      const { data, meta } = await super.findOne(ctx);
+      return { data, meta };
+    }
+  })); 


### PR DESCRIPTION
  feat(transparency-ethics): add custom controller and permissions for frontend integration

  - Implement custom controller to ensure document population
  - Configure public permissions for find and findOne endpoints
  - Enable seamless connection with frontend Transparency & Ethics section